### PR TITLE
Add Nginx logging, and avoid unwanted warn messages in logs

### DIFF
--- a/docker/client_nginx.conf
+++ b/docker/client_nginx.conf
@@ -11,6 +11,8 @@ server {
     # max upload size
     client_max_body_size 40M;   # adjust to taste
 
+    client_body_buffer_size 10M;
+
 #    # Do NOT serve the Django media location (/media usually) directly as tis will be protected and served via django in the portal
 
     location /static {
@@ -31,4 +33,8 @@ server {
         uwsgi_pass   unix:///run/client.sock;
         include     /opt/django/ap-nimbus-client/docker/uwsgi_params; # the uwsgi_params file you installed
     }
+
+    access_log /opt/django/media/nginx_access.log;
+    error_log /opt/django/media/nginx_error.log info;
+
 }


### PR DESCRIPTION
Currently there doesn't appear to be a logging strategy for Nginx in the config so I'm proposing provisionally putting the logs in `/opt/django/media/` because :

1. If someone misconfigures or is having problems with Nginx, then they'll have some log output to look at.
2. That's where the `uwsgi.log` is being written too, so it'll be good to have all the logs in the same place.
3. `/opt/django/media/` is the documented docker volume location and is being backed up.

Whether the log files should be appearing in `/opt/django/media/` at all however is something I think should be looked into at a later date (I'll create another issue as an "enhancement"!), because I doubt it'll be the first place someone expects to find log files unless we emphasise it in documentation, i.e. I'd be heading to `/var/log/nginx/` and `/var/log/uwsgi/` by default!

Having started to write stuff to Nginx logs, I then find that they're getting `warn` level messages in them, i.e.,

```
2023/05/04 17:57:15 [warn] 31#31: *5 a client request body is buffered to a temporary file /var/lib/nginx/body/0000000001, client: 192.168.32.1, server: , request: "POST /simulations/new HTTP/1.1", host: "localhost:4240", referrer: "https://toshiba-gef/ActionPotentialPortal/simulations/new"
2023/05/04 17:58:30 [warn] 31#31: *5 an upstream response is buffered to a temporary file /var/lib/nginx/uwsgi/2/00/0000000002 while reading upstream, client: 192.168.32.1, server: , request: "GET /simulations/1/data HTTP/1.1", upstream: "uwsgi://unix:///run/client.sock:", host: "localhost:4240", referrer: "https://toshiba-gef/ActionPotentialPortal/simulations/1/result"
```

This is when PKPD files were being used and indicates (based on [serverfault.com](https://serverfault.com/questions/511789/nginx-client-request-body-is-buffered-to-a-temporary-file)) that there's a probably negligible delay in file transfer, but putting `assigning client_body_buffer_size 10M;` should prevent those messages (up to 10Mb).