### PR TITLE
Enable in-container access to uwsgi.log

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,9 +36,10 @@ RUN ln -s /opt/django/ap-nimbus-client/docker/client_nginx.conf /etc/nginx/sites
 
 # allow appredict to control uwsgi and nginx
 WORKDIR /opt/django/ap-nimbus-client/client
-RUN echo "Defaults!/usr/local/bin/uwsgi setenv" >> /etc/sudoers
-RUN echo "appredict ALL=(ALL) NOPASSWD: /etc/init.d/nginx" >> /etc/sudoers
-RUN echo "appredict ALL=(ALL) NOPASSWD: /usr/local/bin/uwsgi" >> /etc/sudoers
+RUN echo '\nDefaults!/usr/local/bin/uwsgi setenv\n\
+appredict ALL=(ALL) NOPASSWD: /etc/init.d/nginx\n\
+appredict ALL=(ALL) NOPASSWD: /usr/local/bin/uwsgi\n\
+appredict ALL=(ALL) NOPASSWD: /bin/cat /opt/django/media/uwsgi.log, /usr/bin/tail -f /opt/django/media/uwsgi.log\n' >> /etc/sudoers
 
 # make sure appredict owns the django files
 RUN chown -R appredict:appredict /opt/django/


### PR DESCRIPTION
I noticed whilst working in a running container, user `appredict` couldn't access `/opt/django/media/uwsgi.log` due to the latter being accessible only to `root`. It may help in the developer case of `/opt/django/media/` not being defined as a docker volume.

Also, fwiw, I think having a single `RUN` is a v. small improvement.