### PR TITLE
Changed to only create admin account if it doesn't exist

### DIFF
--- a/client/accounts/management/commands/create_admin.py
+++ b/client/accounts/management/commands/create_admin.py
@@ -23,11 +23,3 @@ class Command(BaseCommand):
                                 is_superuser=True,
                                 is_staff=True,
                                 is_active=True)
-        else:
-            user = User.objects.get(email=email)
-            user.institution = institution
-            user.password = password
-            user.is_superuser = True
-            user.is_staff = True
-            user.is_active = True
-            user.save()

--- a/client/accounts/management/commands/create_admin.py
+++ b/client/accounts/management/commands/create_admin.py
@@ -6,16 +6,18 @@ from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    help = ('Create superuser or set the username and password if superuser with the given email already exists. '
-            'The command uses DJANGO_SUPERUSER_EMAIL DJANGO_SUPERUSER_USERNAME DJANGO_SUPERUSER_INSTITUTION and '
-            'DJANGO_SUPERUSER_PASSWORD environment variables')
+    help = ('Create Django superuser by: (1) new user on application initialisation; or (2) new user if '
+            'not currently in the system; or (3) elevation of privileges of existing user. '
+            'Users are identified by their email address. '
+            'See https://ap-nimbus.readthedocs.io/en/latest/running/client-direct/index.html#environment-variables')
 
     def handle(self, *args, **kwargs):
         email = os.environ.get('DJANGO_SUPERUSER_EMAIL')
-        full_name = os.environ.get('DJANGO_SUPERUSER_USERNAME', email)
+        full_name = os.environ.get('DJANGO_SUPERUSER_FULLNAME', email)
         institution = os.environ.get('DJANGO_SUPERUSER_INSTITUTION', 'unknown')
         password = make_password(os.environ.get('DJANGO_SUPERUSER_PASSWORD'))
         if not User.objects.filter(email=email).exists():
+            # User with specified email does not exist. Create new user from env var values.
             User.objects.create(email=email,
                                 full_name=full_name,
                                 institution=institution,
@@ -23,3 +25,13 @@ class Command(BaseCommand):
                                 is_superuser=True,
                                 is_staff=True,
                                 is_active=True)
+        else:
+            # User with specified email exists. Overwrite retrieved values with env var values.
+            user = User.objects.get(email=email)
+            user.full_name = full_name
+            user.institution = institution
+            user.password = password
+            user.is_superuser = True
+            user.is_staff = True
+            user.is_active = True
+            user.save()

--- a/client/accounts/tests/test_commands.py
+++ b/client/accounts/tests/test_commands.py
@@ -17,8 +17,7 @@ def test_create_admin():
     user = User.objects.get(email='x@y.com')
     assert user.institution == 'notts'
     assert check_password('password', user.password)
-    
+
     assert User.objects.filter(email='x@y.com').count() == 1
     call_command('create_admin')
     assert User.objects.filter(email='x@y.com').count() == 1
-    

--- a/client/accounts/tests/test_commands.py
+++ b/client/accounts/tests/test_commands.py
@@ -17,3 +17,8 @@ def test_create_admin():
     user = User.objects.get(email='x@y.com')
     assert user.institution == 'notts'
     assert check_password('password', user.password)
+    
+    assert User.objects.filter(email='x@y.com').count() == 1
+    call_command('create_admin')
+    assert User.objects.filter(email='x@y.com').count() == 1
+    

--- a/client/accounts/tests/test_commands.py
+++ b/client/accounts/tests/test_commands.py
@@ -17,11 +17,3 @@ def test_create_admin():
     user = User.objects.get(email='x@y.com')
     assert user.institution == 'notts'
     assert check_password('password', user.password)
-
-    os.environ['DJANGO_SUPERUSER_PASSWORD'] = 'password2'
-    os.environ['DJANGO_SUPERUSER_INSTITUTION'] = 'oxford'
-    call_command('create_admin')
-    user = User.objects.get(email='x@y.com')
-    user.refresh_from_db()
-    assert user.institution == 'oxford'
-    assert check_password('password2', user.password)

--- a/client/files/migrations/0002_auto_20220105_1304.py
+++ b/client/files/migrations/0002_auto_20220105_1304.py
@@ -148,7 +148,7 @@ def create_admin(apps, schema_editor):
     User = apps.get_model('accounts', 'User')
     email = os.environ.get('DJANGO_SUPERUSER_EMAIL')
     if not User.objects.filter(email=email).exists():
-        full_name = os.environ.get('DJANGO_SUPERUSER_USERNAME', email)
+        full_name = os.environ.get('DJANGO_SUPERUSER_FULLNAME', email)
         institution = os.environ.get('DJANGO_SUPERUSER_INSTITUTION', 'unknown')
         password = os.environ.get('DJANGO_SUPERUSER_PASSWORD')
         User.objects.create(

--- a/client/files/migrations/0002_auto_20220105_1304.py
+++ b/client/files/migrations/0002_auto_20220105_1304.py
@@ -147,18 +147,19 @@ def create_admin(apps, schema_editor):
     # version than this migration expects. We use the historical version.
     User = apps.get_model('accounts', 'User')
     email = os.environ.get('DJANGO_SUPERUSER_EMAIL')
-    full_name = os.environ.get('DJANGO_SUPERUSER_USERNAME', email)
-    institution = os.environ.get('DJANGO_SUPERUSER_INSTITUTION', 'unknown')
-    password = os.environ.get('DJANGO_SUPERUSER_PASSWORD')
-    User.objects.create(
-            email=email,
-            full_name=full_name,
-            institution=institution,
-            password=make_password(password),
-            is_superuser=True,
-            is_staff=True,
-            is_active=True,
-    )
+    if not User.objects.filter(email=email).exists():
+        full_name = os.environ.get('DJANGO_SUPERUSER_USERNAME', email)
+        institution = os.environ.get('DJANGO_SUPERUSER_INSTITUTION', 'unknown')
+        password = os.environ.get('DJANGO_SUPERUSER_PASSWORD')
+        User.objects.create(
+                email=email,
+                full_name=full_name,
+                institution=institution,
+                password=make_password(password),
+                is_superuser=True,
+                is_staff=True,
+                is_active=True,
+        )
 
 
 def create_predefined_currents(apps, schema_editor):

--- a/docker/env
+++ b/docker/env
@@ -3,14 +3,14 @@
 # please pick a secret key a long random string is ideal
 DJANGO_SECRET_KEY=
 
-# please replace the email by the address of your first superuser, which will be able to long into django as admin
-# Also include a password
-Please note that the password will NOT be reset in case the superuser already exists. If you have lust the superuse password, you can use the normal reset functionality
+# Please provide the full set of Django superuser details below prior to application initiation, to
+# allow this sole superuser to log in on first boot.
+# If you wish to change the Django superuser after application initialisation, please read the
+# information in https://ap-nimbus.readthedocs.io/en/latest/running/client-direct/index.html#environment-variables
 DJANGO_SUPERUSER_EMAIL=
+DJANGO_SUPERUSER_FULLNAME=
 DJANGO_SUPERUSER_PASSWORD=
-
-# please replace with the name of your institution
-DJANGO_SUPERUSER_INSTITUTION=Nottingham
+DJANGO_SUPERUSER_INSTITUTION=
 
 # this is intended for situations where the client is running behind a proxy and a subfolder is forwarded to it. This variable will ensure the urls used will correctly contain the relevant subfolder
 subfolder=

--- a/docker/env
+++ b/docker/env
@@ -4,9 +4,9 @@
 DJANGO_SECRET_KEY=
 
 # please replace the email by the address of your first superuser, which will be able to long into django as admin
+# Also include a password
+Please note that the password will NOT be reset in case the superuser already exists. If you have lust the superuse password, you can use the normal reset functionality
 DJANGO_SUPERUSER_EMAIL=
-
-# please pick a secure password for the superuser
 DJANGO_SUPERUSER_PASSWORD=
 
 # please replace with the name of your institution


### PR DESCRIPTION
this should fix #115 I think, but it needs further testing: first whether it fixes @flawmop 's issues and if it does we need to check it does actually create the admin account if I change the account details in the env file to one that does not yet exist