### PR TITLE
ldap authentication + docker compose example + sqlite option

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,6 +29,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        apt-get update
+        apt-get install -y libldap2-dev libsasl2-dev
         python -m pip install --upgrade pip wheel
         python -m pip install flake8 pytest pytest-django
         python -m pip install -r requirements/requirements.txt

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,8 +29,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        apt-get update
-        apt-get install -y libldap2-dev libsasl2-dev
+        sudo apt-get update
+        sudo apt-get install -y libldap2-dev libsasl2-dev
         python -m pip install --upgrade pip wheel
         python -m pip install flake8 pytest pytest-django
         python -m pip install -r requirements/requirements.txt

--- a/client/accounts/forms.py
+++ b/client/accounts/forms.py
@@ -21,7 +21,7 @@ class RegistrationForm(auth_forms.UserCreationForm):
         super().__init__(*args, **kwargs)
 
     def clean(self):
-        if settings.AUTH_USE_LDAP:
+        if settings.AP_PREDICT_LDAP:
             self.add_error(None, 'Registration is disabled when using LDAP')
         return super().clean()
 

--- a/client/accounts/forms.py
+++ b/client/accounts/forms.py
@@ -1,9 +1,9 @@
 from django import forms
+from django.conf import settings
 from django.contrib.auth import forms as auth_forms
 
 from .emails import send_user_creation_email
 from .models import User
-from django.conf import settings
 
 
 class RegistrationForm(auth_forms.UserCreationForm):

--- a/client/accounts/forms.py
+++ b/client/accounts/forms.py
@@ -3,6 +3,7 @@ from django.contrib.auth import forms as auth_forms
 
 from .emails import send_user_creation_email
 from .models import User
+from django.conf import settings
 
 
 class RegistrationForm(auth_forms.UserCreationForm):
@@ -18,6 +19,11 @@ class RegistrationForm(auth_forms.UserCreationForm):
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop('request')
         super().__init__(*args, **kwargs)
+
+    def clean(self):
+        if settings.AUTH_USE_LDAP:
+            self.add_error(None, 'Registration is disabled when using LDAP')
+        return super().clean()
 
     def save(self, commit=True):
         user = super().save(commit=commit)

--- a/client/accounts/tests/test_views.py
+++ b/client/accounts/tests/test_views.py
@@ -69,12 +69,12 @@ def test_register(client, settings):
 
     assert not User.objects.filter(email=data['email']).exists()
 
-    settings.AUTH_USE_LDAP = True
+    settings.AP_PREDICT_LDAP = True
     response = client.post('/accounts/register/', data=data)
     assert 'Registration is disabled when using LDAP' in str(response.content)
     assert not User.objects.filter(email=data['email'])
 
-    settings.AUTH_USE_LDAP = False
+    settings.AP_PREDICT_LDAP = False
     client.post('/accounts/register/', data=data)
     assert User.objects.filter(email=data['email']).exists()
     assert len(mail.outbox) == num_mails + 1

--- a/client/accounts/tests/test_views.py
+++ b/client/accounts/tests/test_views.py
@@ -59,7 +59,7 @@ def test_can_register(client):
 
 
 @pytest.mark.django_db
-def test_register(client):
+def test_register(client, settings):
     num_mails = len(mail.outbox)
     data = {'email': 'test@test.com',
             'institution': 'uon',
@@ -69,6 +69,12 @@ def test_register(client):
 
     assert not User.objects.filter(email=data['email']).exists()
 
+    settings.AUTH_USE_LDAP = True
+    response = client.post('/accounts/register/', data=data)
+    assert 'Registration is disabled when using LDAP' in str(response.content)
+    assert not User.objects.filter(email=data['email'])
+
+    settings.AUTH_USE_LDAP = False
     client.post('/accounts/register/', data=data)
     assert User.objects.filter(email=data['email']).exists()
     assert len(mail.outbox) == num_mails + 1

--- a/client/accounts/urls.py
+++ b/client/accounts/urls.py
@@ -30,4 +30,5 @@ urlpatterns = [
     ),
 
 ]
+
 app_name = 'accounts'

--- a/client/config/develop_settings.py
+++ b/client/config/develop_settings.py
@@ -1,5 +1,7 @@
 import os
+
 from dotenv import load_dotenv
+
 
 load_dotenv()
 

--- a/client/config/develop_settings.py
+++ b/client/config/develop_settings.py
@@ -1,4 +1,7 @@
 import os
+from dotenv import load_dotenv
+
+load_dotenv() 
 
 from .production_settings import *  # noqa
 from .production_settings import BASE_DIR
@@ -8,6 +11,16 @@ from .production_settings import BASE_DIR
 DEBUG = True
 
 ALLOWED_HOSTS = ['*']
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+        "OPTIONS": {
+            # 'timeout': 20,
+        },
+    }
+}
 
 TEMPLATES = [
     {
@@ -25,5 +38,19 @@ TEMPLATES = [
         },
     },
 ]
+
+LOGGING = {
+   "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "DEBUG",
+    },
+}
 
 

--- a/client/config/develop_settings.py
+++ b/client/config/develop_settings.py
@@ -1,16 +1,19 @@
 import os
 from dotenv import load_dotenv
 
-load_dotenv() 
+load_dotenv()
 
 from .production_settings import *  # noqa
-from .production_settings import BASE_DIR
+from .production_settings import BASE_DIR  # noqa
+
+
+MEDIA_ROOT = "."
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 AP_PREDICT_SQLITE = bool(int(os.environ.get("AP_PREDICT_SQLITE", "0")))
 if AP_PREDICT_SQLITE:
@@ -22,27 +25,27 @@ if AP_PREDICT_SQLITE:
                 # 'timeout': 20,
             },
         }
-}
+    }
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, 'templates')],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-                'core.context_processors.common',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [os.path.join(BASE_DIR, "templates")],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "core.context_processors.common",
             ],
         },
     },
 ]
 
 LOGGING = {
-   "version": 1,
+    "version": 1,
     "disable_existing_loggers": False,
     "handlers": {
         "console": {
@@ -54,5 +57,3 @@ LOGGING = {
         "level": "DEBUG",
     },
 }
-
-

--- a/client/config/develop_settings.py
+++ b/client/config/develop_settings.py
@@ -12,14 +12,16 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
-        "OPTIONS": {
-            # 'timeout': 20,
-        },
-    }
+AP_PREDICT_SQLITE = bool(int(os.environ.get("AP_PREDICT_SQLITE", "0")))
+if AP_PREDICT_SQLITE:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+            "OPTIONS": {
+                # 'timeout': 20,
+            },
+        }
 }
 
 TEMPLATES = [

--- a/client/config/production_settings.py
+++ b/client/config/production_settings.py
@@ -20,107 +20,112 @@ from django_auth_ldap.config import LDAPSearch, GroupOfNamesType, LDAPSearchUnio
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 APPREDICT_LOOKUP_TABLE_MANIFEST = os.environ.get(
-    'APPREDICT_LOOKUP_TABLE_MANIFEST',
-    'https://cardiac.nottingham.ac.uk/lookup_tables/appredict_lookup_table_manifest.txt'
+    "APPREDICT_LOOKUP_TABLE_MANIFEST",
+    "https://cardiac.nottingham.ac.uk/lookup_tables/appredict_lookup_table_manifest.txt",
 )
 
 # running in subfolder
-subfolder = os.environ.get('subfolder', None)
-FORCE_SCRIPT_NAME = '/%s/' % subfolder if subfolder else ''
-AUTH_USER_MODEL = 'accounts.User'
+subfolder = os.environ.get("subfolder", None)
+FORCE_SCRIPT_NAME = "/%s/" % subfolder if subfolder else ""
+AUTH_USER_MODEL = "accounts.User"
 LOGIN_REDIRECT_URL = FORCE_SCRIPT_NAME
 LOGOUT_REDIRECT_URL = FORCE_SCRIPT_NAME
-LOGIN_URL = ('%s/accounts/login/' % FORCE_SCRIPT_NAME).replace('//', '/')
+LOGIN_URL = ("%s/accounts/login/" % FORCE_SCRIPT_NAME).replace("//", "/")
 
 # email
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = os.environ.get('smtp_server', 'localhost')
-SERVER_EMAIL = os.environ.get('django_email_from_addr', os.environ['DJANGO_SUPERUSER_EMAIL'])
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = os.environ.get("smtp_server", "localhost")
+SERVER_EMAIL = os.environ.get(
+    "django_email_from_addr", os.environ["DJANGO_SUPERUSER_EMAIL"]
+)
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
-WELCOME_SUBJECT = os.environ.get('WELCOME_SUBJECT', '[AP Portal] Welcome')
+WELCOME_SUBJECT = os.environ.get("WELCOME_SUBJECT", "[AP Portal] Welcome")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '*').split(',')
+ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(",")
 
 
 # Application definition
 
 DJANGO_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
 ]
 
 LOCAL_APPS = [
-    'core',
-    'accounts',
-    'files',
-    'simulations',
+    "core",
+    "accounts",
+    "files",
+    "simulations",
 ]
 
 INSTALLED_APPS = DJANGO_APPS + LOCAL_APPS
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'config.urls'
+ROOT_URLCONF = "config.urls"
 
 # Cache templates for production
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, 'templates')],
-        'APP_DIRS': False,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-                'core.context_processors.common',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [os.path.join(BASE_DIR, "templates")],
+        "APP_DIRS": False,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "core.context_processors.common",
             ],
-            'loaders': [
-                ('django.template.loaders.cached.Loader', [
-                    'django.template.loaders.filesystem.Loader',
-                    'django.template.loaders.app_directories.Loader',
-                ]),
+            "loaders": [
+                (
+                    "django.template.loaders.cached.Loader",
+                    [
+                        "django.template.loaders.filesystem.Loader",
+                        "django.template.loaders.app_directories.Loader",
+                    ],
+                ),
             ],
         },
     },
 ]
 
 
-WSGI_APPLICATION = 'config.wsgi.application'
+WSGI_APPLICATION = "config.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ['PGDATABASE'],
-        'USER': os.environ['PGUSER'],
-        'PASSWORD': os.environ['PGPASSWORD'],
-        'HOST': os.environ['PGHOST'],
-        'PORT': os.environ['PGPORT'],
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ["PGDATABASE"],
+        "USER": os.environ["PGUSER"],
+        "PASSWORD": os.environ["PGPASSWORD"],
+        "HOST": os.environ["PGHOST"],
+        "PORT": os.environ["PGPORT"],
     }
 }
 
@@ -130,16 +135,16 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -147,9 +152,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = False
 
@@ -159,43 +164,43 @@ USE_TZ = False
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
-STATIC_URL = ('%s/static/' % FORCE_SCRIPT_NAME).replace('//', '/')
-STATIC_ROOT = '/opt/django/staticfiles'
+STATIC_URL = ("%s/static/" % FORCE_SCRIPT_NAME).replace("//", "/")
+STATIC_ROOT = "/opt/django/staticfiles"
 STATICFILES_DIRS = [
-    str(BASE_DIR / 'static'),
+    str(BASE_DIR / "static"),
 ]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Use forwarded headers for anything that requires a hostname.
 USE_X_FORWARDED_HOST = True
 
 
 # Media files (Uploaded files)
-MEDIA_URL = FORCE_SCRIPT_NAME + 'media/'
-MEDIA_ROOT = '/opt/django/media/'
+MEDIA_URL = FORCE_SCRIPT_NAME + "media/"
+MEDIA_ROOT = "/opt/django/media/"
 
 # Force using temporary fiile for upload
-FILE_UPLOAD_HANDLERS = ['django.core.files.uploadhandler.TemporaryFileUploadHandler']
+FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.TemporaryFileUploadHandler"]
 
 # API location for AP manager
-AP_PREDICT_ENDPOINT = os.environ.get('AP_PREDICT_ENDPOINT', 'http://path_to_ap_manager')
-AP_PREDICT_STATUS_TIMEOUT = int(os.environ.get('AP_PREDICT_STATUS_TIMEOUT', 1000))
+AP_PREDICT_ENDPOINT = os.environ.get("AP_PREDICT_ENDPOINT", "http://path_to_ap_manager")
+AP_PREDICT_STATUS_TIMEOUT = int(os.environ.get("AP_PREDICT_STATUS_TIMEOUT", 1000))
 
 # Hosting information for the privacy policy
-HOSTING_INFO = os.environ.get('HOSTING_INFO', '')
+HOSTING_INFO = os.environ.get("HOSTING_INFO", "")
 
 # A brief statement that will be shown at the start of the privacy notice
-PRIVACY_NOTICE = os.environ.get('PRIVACY_NOTICE', '').replace('\\n', '<br/>')
+PRIVACY_NOTICE = os.environ.get("PRIVACY_NOTICE", "").replace("\\n", "<br/>")
 
 # Mailto link for contacting maintiners
-CONTACT_MAILTO = os.environ.get('CONTACT_MAILTO', '')
+CONTACT_MAILTO = os.environ.get("CONTACT_MAILTO", "")
 
 # Contact text for contacting maintiners
-CONTACT_TEXT = os.environ.get('CONTACT_TEXT', '')
+CONTACT_TEXT = os.environ.get("CONTACT_TEXT", "")
 
 # prevent unwated HTTP access
 CSRF_COOKIE_SECURE = True
@@ -213,6 +218,7 @@ if AP_PREDICT_LDAP:
     AUTH_LDAP_SERVER_URI = os.environ.get(
         "AUTH_LDAP_SERVER_URI", "ldap://ldap.forumsys.com:389"
     )
+    AUTH_LDAP_USER_ATTR_MAP = {"first_name": "givenName", "last_name": "sn", "full_name": "cn"}
 
     user_group = os.environ.get("AUTH_LDAP_USER_GROUP", None)
     admin_group = os.environ.get("AUTH_LDAP_ADMIN_GROUP", None)
@@ -245,7 +251,5 @@ if AP_PREDICT_LDAP:
     for base_index in [2, 3, 4, 5]:
         search_base = os.environ.get(f"AUTH_LDAP_SEARCH_BASE{base_index}", None)
         if search_base is not None:
-            searches.append(
-                LDAPSearch(search_base, ldap.SCOPE_SUBTREE, search_filter)
-            )
+            searches.append(LDAPSearch(search_base, ldap.SCOPE_SUBTREE, search_filter))
     AUTH_LDAP_USER_SEARCH = LDAPSearchUnion(*searches)

--- a/client/config/production_settings.py
+++ b/client/config/production_settings.py
@@ -204,8 +204,8 @@ SESSION_COOKIE_SECURE = False
 # unlimited persistent connections
 CONN_MAX_AGE = None
 
-AUTH_USE_LDAP = bool(int(os.environ.get("AUTH_USE_LDAP", "0")))
-if AUTH_USE_LDAP:
+AP_PREDICT_LDAP = bool(int(os.environ.get("AP_PREDICT_LDAP", "0")))
+if AP_PREDICT_LDAP:
     AUTHENTICATION_BACKENDS = [
         "django_auth_ldap.backend.LDAPBackend",
         "django.contrib.auth.backends.ModelBackend",
@@ -217,8 +217,6 @@ if AUTH_USE_LDAP:
     user_group = os.environ.get("AUTH_LDAP_USER_GROUP", None)
     admin_group = os.environ.get("AUTH_LDAP_ADMIN_GROUP", None)
     group_search = os.environ.get("AUTH_LDAP_GROUP_SEARCH", None)
-
-    
 
     if group_search is not None:
         AUTH_LDAP_GROUP_SEARCH = LDAPSearch(

--- a/client/config/production_settings.py
+++ b/client/config/production_settings.py
@@ -12,8 +12,9 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 
 import os
 from pathlib import Path
+
 import ldap
-from django_auth_ldap.config import LDAPSearch, GroupOfNamesType, LDAPSearchUnion
+from django_auth_ldap.config import GroupOfNamesType, LDAPSearch, LDAPSearchUnion
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.

--- a/client/core/context_processors.py
+++ b/client/core/context_processors.py
@@ -4,5 +4,5 @@ from django.conf import settings
 def common(request):
     return {
         'INFO_MESSAGES': messages.get_messages(request), 
-        'AUTH_USE_LDAP': settings.AUTH_USE_LDAP
+        'AP_PREDICT_LDAP': settings.AP_PREDICT_LDAP
     }

--- a/client/core/context_processors.py
+++ b/client/core/context_processors.py
@@ -1,5 +1,5 @@
-from django.contrib import messages
 from django.conf import settings
+from django.contrib import messages
 
 
 def common(request):

--- a/client/core/context_processors.py
+++ b/client/core/context_processors.py
@@ -1,5 +1,8 @@
 from django.contrib import messages
-
+from django.conf import settings
 
 def common(request):
-    return {'INFO_MESSAGES': messages.get_messages(request)}
+    return {
+        'INFO_MESSAGES': messages.get_messages(request), 
+        'AUTH_USE_LDAP': settings.AUTH_USE_LDAP
+    }

--- a/client/core/context_processors.py
+++ b/client/core/context_processors.py
@@ -1,8 +1,9 @@
 from django.contrib import messages
 from django.conf import settings
 
+
 def common(request):
     return {
-        'INFO_MESSAGES': messages.get_messages(request), 
-        'AP_PREDICT_LDAP': settings.AP_PREDICT_LDAP
+        "INFO_MESSAGES": messages.get_messages(request),
+        "AP_PREDICT_LDAP": settings.AP_PREDICT_LDAP,
     }

--- a/client/templates/includes/navbar.html
+++ b/client/templates/includes/navbar.html
@@ -25,7 +25,7 @@
         </li>
     {% else %}
       <li><a href="{% url 'accounts:login' %}?next={{ request.path }}">Log in</a></li>
-      {% if not AUTH_USE_LDAP %}
+      {% if not AP_PREDICT_LDAP %}
         <li><a href="{% url 'accounts:register' %}">Register</a></li>
       {% endif %}
     {% endif %}

--- a/client/templates/includes/navbar.html
+++ b/client/templates/includes/navbar.html
@@ -25,7 +25,9 @@
         </li>
     {% else %}
       <li><a href="{% url 'accounts:login' %}?next={{ request.path }}">Log in</a></li>
-      <li><a href="{% url 'accounts:register' %}">Register</a></li>
+      {% if not AUTH_USE_LDAP %}
+        <li><a href="{% url 'accounts:register' %}">Register</a></li>
+      {% endif %}
     {% endif %}
   </ul>
 </nav>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get install -y --no-install-recommends \
     uwsgi \
     uwsgi-plugin-python3 \
     libpcre3-dev \
+    libldap2-dev libsasl2-dev slapd ldap-utils
     sudo && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,8 +29,7 @@ RUN apt-get install -y --no-install-recommends \
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
-# get the client from git & install
-RUN git clone --recursive --branch master --depth 1 https://github.com/CardiacModelling/ap-nimbus-client.git
+COPY . /opt/django/ap-nimbus-client
 RUN python -m pip install -r /opt/django/ap-nimbus-client/requirements/requirements.txt
 RUN rm /etc/nginx/sites-enabled/*
 RUN ln -s /opt/django/ap-nimbus-client/docker/client_nginx.conf /etc/nginx/sites-enabled/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y --no-install-recommends \
     uwsgi \
     uwsgi-plugin-python3 \
     libpcre3-dev \
-    libldap2-dev libsasl2-dev slapd ldap-utils
+    libldap2-dev libsasl2-dev \
     sudo && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -3,6 +3,7 @@ services:
     image: ap-nimbus-client-direct
     depends_on:
       - name-postgres
+      - name-app-manager
     build:
       context: ../ 
       dockerfile: ./docker/Dockerfile

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,25 @@
+services:
+  name-client:
+    image: ap-nimbus-client-direct
+    build:
+      context: ./ 
+      dockerfile: ./docker/Dockerfile
+    ports:
+      - "80:80"
+    restart: unless-stopped
+    volumes:
+      - volume-client:/opt/django/media
+    env_file:
+     - .env
+  name-postgres:
+    image: postgres:14.1-bullseye
+    restart: unless-stopped
+    volumes:
+      - volume-postgres:/var/lib/postgresql/data
+    env_file:
+     - .env
+
+
+volumes:
+  volume-client:
+  volume-postgres:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,8 +1,10 @@
 services:
   name-client:
     image: ap-nimbus-client-direct
+    depends_on:
+      - name-postgres
     build:
-      context: ./ 
+      context: ../ 
       dockerfile: ./docker/Dockerfile
     ports:
       - "80:80"
@@ -10,16 +12,22 @@ services:
     volumes:
       - volume-client:/opt/django/media
     env_file:
-     - .env
+      - ../.env
+  name-app-manager:
+    image: cardiacmodelling/ap-nimbus-app-manager:1.0.0
+    restart: unless-stopped
+    volumes:
+      - volume-app-manager:/home/appredict/apps/app-manager
   name-postgres:
     image: postgres:14.1-bullseye
     restart: unless-stopped
     volumes:
       - volume-postgres:/var/lib/postgresql/data
     env_file:
-     - .env
+      - ../.env
 
 
 volumes:
   volume-client:
   volume-postgres:
+  volume-app-manager:

--- a/docker/env
+++ b/docker/env
@@ -35,7 +35,7 @@ PGHOST=name-postgres
 PGUSER=postgres
 
 # Location of the AP predict endpoint (usually in your docker network, but could be set to be elsewhere)
-AP_PREDICT_ENDPOINT=http://ap-nimbus-network:8080
+AP_PREDICT_ENDPOINT=http://name-app-manager:8080
 
 #Supply a brief sentence about where this instance is hosted (in html format, without newlines
 HOSTING_INFO=""

--- a/docker/env
+++ b/docker/env
@@ -51,3 +51,36 @@ CONTACT_TEXT=""
 
 # Status timeout, after this time the portal assumes something has gone wrong and stops trying to get a status update
 AP_PREDICT_STATUS_TIMEOUT=1000
+
+# LDAP settings (set AP_PREDICT_LDAP=1 to enable, none of the other settings are required if this is not set)
+AP_PREDICT_LDAP=0
+
+# LDAP server URI
+AUTH_LDAP_SERVER_URI=ldap://ldap.forumsys.com:389
+
+# distinguished name of an authorized user
+AUTH_LDAP_BIND_DN=cn=read-only-admin,dc=example,dc=com
+
+# password for the authorized user
+AUTH_LDAP_BIND_PASSWORD=password
+
+# where to perform the search
+AUTH_LDAP_SEARCH_BASE=dc=example,dc=com
+
+# additional search bases (optional)
+AUTH_LDAP_SEARCH_BASE2=
+AUTH_LDAP_SEARCH_BASE3=
+AUTH_LDAP_SEARCH_BASE4=
+AUTH_LDAP_SEARCH_BASE5=
+
+# search filter based on authenticated username
+AUTH_LDAP_SEARCH_FILTER=uid=%(user)s
+
+# LDAP group search (optional, e.g. ou=mathematicians,dc=example,dc=com). An LDAPSearch object that identifies the set of relevant group objects
+AUTH_LDAP_GROUP_SEARCH=
+
+# Users must be in this group to be able to log in (optional, e.g. cn=users,ou=mathematicians,dc=example,dc=com)
+AUTH_LDAP_USER_GROUP=
+
+# Users in this group will log in as superusers (optional, e.g. cn=admin,ou=mathematicians,dc=example,dc=com)
+AUTH_LDAP_ADMIN_GROUP=

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,4 +8,3 @@ pytest-httpx>=0.22.0,<0.30
 pytest-asyncio==0.23.7
 openpyxl==3.1.4
 pandas>=1.5.2,<2.3
-python-dotenv==1.0.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,3 +8,4 @@ pytest-httpx>=0.22.0,<0.30
 pytest-asyncio==0.23.7
 openpyxl==3.1.4
 pandas>=1.5.2,<2.3
+python-dotenv==1.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,3 +9,4 @@ xlsxwriter==3.1.9
 jsonschema==4.22.0
 xmltodict==0.13.0
 numpy>=1.24.4,<2.0
+django-auth-ldap==4.8.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,3 +10,4 @@ jsonschema==4.22.0
 xmltodict==0.13.0
 numpy>=1.24.4,<2.0
 django-auth-ldap==4.8.0
+python-dotenv==1.0.1


### PR DESCRIPTION
Fixes #132

This adds an option to authenticate via a ldap server, with logging in users as either normal users or admin depending on the ldap groups they are assigned to. This feature is controlled by a number of environment variables, which I've added to the example env file with some comments

It also adds some other quality-of-life stuff that I found useful, let me know if this is what you want:
- the develop settings include an option to use an sqlite database rather than postgres (I found this useful for developing outside a docker container)
- the develop settings add some debug logging
- the develop settings use python dotenv to load up a .env file if it exists (again I found this useful for developing outside a docker container)
- I've added docker-compose.yaml file for easy deployment of the client-direct app
- I've edited the Dockerfile to copy the current context dir rather than cloning from the master branch of the repo. This allows you to deploy from a custom branch or commit.